### PR TITLE
Addition of transparent option for image rendering

### DIFF
--- a/lib/rqrcode_png/image.rb
+++ b/lib/rqrcode_png/image.rb
@@ -1,15 +1,16 @@
 module RQRCodePNG
   class Image
     BLACK = ::ChunkyPNG::Color::BLACK
-    WHITE = ::ChunkyPNG::Color::WHITE		
+    WHITE = ::ChunkyPNG::Color::WHITE	
+    TRANSPARENT = ::ChunkyPNG::Color::TRANSPARENT	
 
     def initialize(qr_code)
       @sequence = Sequence.new(qr_code)
     end
 
     # Returns an image file of the QR Code
-    def render
-      png = blank_img()
+    def render bg_color = WHITE
+      png = blank_img(bg_color)
       @sequence.dark_squares_only do |x, y|
         png[y + @sequence.border_width(), x + @sequence.border_width()] = BLACK
       end
@@ -24,8 +25,8 @@ module RQRCodePNG
     end
 
     # Returns an appropriately sized, blank (white) image
-    def blank_img
-      ::ChunkyPNG::Image.new(img_size(), img_size(), WHITE)
+    def blank_img bg_color = WHITE
+      ::ChunkyPNG::Image.new(img_size(), img_size(), bg_color)
     end
   end
 end

--- a/lib/rqrcode_png/qrcode_extensions.rb
+++ b/lib/rqrcode_png/qrcode_extensions.rb
@@ -1,8 +1,8 @@
 module RQRCodePNG
   module QRCodeExtensions 
     # This method returns a 33x33 .png of the code
-    def to_img
-      return Image.new(self).render()
+    def to_img(bg_color = ChunkyPNG::Color::WHITE)
+      return Image.new(self).render(bg_color)
     end
   end
 end


### PR DESCRIPTION
When rendering images you have not included the option to select between the various backgrounds available in ChunkyPNG::Color, and it defaults to WHITE.
In this branch I have pass an option where it keeps the default, but accept the TRANSPARENT option or other Color to make the QR Code image suitable for other backgrounds
