### PR TITLE
Update readme to use new dragonfly image accessor

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ gem 'rqrcode_png'
 ```ruby
 # app/models/product.rb
 class Product < ActiveRecord::Base
-  image_accessor :qr_code
+  dragonfly_accessor :qr_code
 end
 ```
 


### PR DESCRIPTION
Dragonfly has changed the accessor to be declared in model. Instead of *image_accessor* it should be *dragonfly_accessor*. I have updated this particular 1 line in docs :)