### PR TITLE
Fix "rqrcode" gem version

### DIFF
--- a/lib/rqrcode_png/version.rb
+++ b/lib/rqrcode_png/version.rb
@@ -1,4 +1,4 @@
 module RqrcodePng
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end
 

--- a/rqrcode_png.gemspec
+++ b/rqrcode_png.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
 
 	s.add_development_dependency "rake"
 	s.add_dependency "chunky_png"
-	s.add_dependency "rqrcode"
+	s.add_dependency "rqrcode", "< 1.0.0"
 
 end


### PR DESCRIPTION
Looks like the new version of "rqrcode" have some internal change. (Using `#checked?` instead `#dark?` call). I fixed this depedency version to solve this issue.

I prefer more fixing the dependency version, and if we change `#dark?` to `#checked?` we can change it to `~> 1` instead left it without versioning.